### PR TITLE
use backslashes, escape for json

### DIFF
--- a/src/ClassLibrary1/ClassLibrary1.csproj
+++ b/src/ClassLibrary1/ClassLibrary1.csproj
@@ -16,6 +16,6 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="GitRootFolder" />
     </Exec>
 
-    <WriteLinesToFile File="$(SourceLink)" Lines="{&quot;documents&quot;: { &quot;$(GitRootFolder)/*&quot; : &quot;$(RepoUri)/$(LatestCommit)/*&quot; }}" />
+    <WriteLinesToFile File="$(SourceLink)" Lines="{&quot;documents&quot;: { &quot;$([System.IO.Path]::GetFullPath('$(GitRootFolder)/').Replace('\','\\'))*&quot; : &quot;$(RepoUri)/$(LatestCommit)/*&quot; }}" />   
   </Target>
 </Project>


### PR DESCRIPTION
This makes the example work with Visual Studio 2017 RC3.
https://github.com/dotnet/roslyn/issues/12759

Also make sure you have your line endings set correctly.
https://ctaggart.github.io/SourceLink/line-endings.html
For example, clone with:
git clone https://github.com/stffabi/sourcelink-test -c core.autocrlf=input

This is because the checksums need to match. GitHub will serve the content with this checksum of `4dceb9b1cc934a16f10e766eab0497ef1d18fde0`:
curl -s https://raw.githubusercontent.com/stffabi/sourcelink-test/b5012a98bed12f6704cb942e92ba34ccdbd920d8/src/ClassLibrary1/Class1.cs | sha1sum | awk '{print $1}'

Which means when you build, it needs to match:
```
PS C:\Users\camer\cs\sourcelink-test> Get-FileHash -Algorithm SHA1 -Path .\src\ClassLibrary1\Class1.cs | fl

Algorithm : SHA1
Hash      : 4DCEB9B1CC934A16F10E766EAB0497EF1D18FDE0
Path      : C:\Users\camer\cs\sourcelink-test\src\ClassLibrary1\Class1.cs
```
