### PR TITLE
add dotnet-sourcelink tool

### DIFF
--- a/src/ClassLibrary1/ClassLibrary1.csproj
+++ b/src/ClassLibrary1/ClassLibrary1.csproj
@@ -18,4 +18,9 @@
 
     <WriteLinesToFile File="$(SourceLink)" Lines="{&quot;documents&quot;: { &quot;$([System.IO.Path]::GetFullPath('$(GitRootFolder)/').Replace('\','\\'))*&quot; : &quot;$(RepoUri)/$(LatestCommit)/*&quot; }}" />   
   </Target>
+  <ItemGroup>
+    <DotNetCliToolReference Include="dotnet-sourcelink">
+      <Version>2.0.0-*</Version>
+    </DotNetCliToolReference>
+  </ItemGroup>
 </Project>

--- a/src/ClassLibrary1/ClassLibrary1.csproj
+++ b/src/ClassLibrary1/ClassLibrary1.csproj
@@ -16,6 +16,6 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="GitRootFolder" />
     </Exec>
 
-    <WriteLinesToFile File="$(SourceLink)" Lines="{&quot;documents&quot;: { &quot;$(GitRootFolder)/*&quot; : &quot;$(RepoUri)/$(LatestCommit)/*&quot; }}" />
+    <WriteLinesToFile File="$(SourceLink)" Lines="{&quot;documents&quot;: { &quot;$([System.IO.Path]::GetFullPath('$(GitRootFolder)/').Replace('\','\\'))*&quot; : &quot;$(RepoUri)/$(LatestCommit)/*&quot; }}" />   
   </Target>
 </Project>


### PR DESCRIPTION
The builds off of #1 & adds a new `dotnet-sourcelink` tool under development. The first command I wrote simply prints the json stored in the pdb. I'll be adding several more tools. As of 2.0.0-b320, here is how to use it:

```
dotnet build
dotnet sourcelink print-json -p .\bin\Debug\netstandard1.4\ClassLibrary1.pdb
```

```
PS C:\Users\camer\cs\sourcelink-test\src\ClassLibrary1> dotnet build
Microsoft (R) Build Engine version 15.1.523.56541
Copyright (C) Microsoft Corporation. All rights reserved.

  18a795d827a4b9913d4d0e1f0e6ac533ab508670
  C:/Users/camer/cs/sourcelink-test
  ClassLibrary1 -> C:\Users\camer\cs\sourcelink-test\src\ClassLibrary1\bin\Debug\netstandard1.4\ClassLibrary1.dll
PS C:\Users\camer\cs\sourcelink-test\src\ClassLibrary1> dotnet sourcelink print-json -p .\bin\Debug\netstandard1.4\ClassLibrary1.pdb
{"documents": { "C:\\Users\\camer\\cs\\sourcelink-test\\*" : "https://raw.githubusercontent.com/stffabi/sourcelink-test/18a795d827a4b9913d4d0e1f0e6ac533ab508670/*" }}
```